### PR TITLE
Avoid fileno for clang compatibility

### DIFF
--- a/tools/wml/Makefile.am
+++ b/tools/wml/Makefile.am
@@ -48,7 +48,7 @@ wmllex.c: wmllex.l
 		else echo "Error: No lexer output file found"; exit 1; fi; \
 	fi
 	@echo "Adding feature test macros to wmllex.c"
-	@sed -i '1i#define _POSIX_C_SOURCE 200809L\n#define _DEFAULT_SOURCE\n#define _GNU_SOURCE' wmllex.c
+	@sed -i '1i#define _POSIX_C_SOURCE 200809L\n#define _DEFAULT_SOURCE\n#define _GNU_SOURCE\n#define _BSD_SOURCE\n#include <stdio.h>\n#include <unistd.h>' wmllex.c
 
 wmluiltok.c: wmluiltok.l
 	@echo "Generating wmluiltok.c from wmluiltok.l"
@@ -61,7 +61,7 @@ wmluiltok.c: wmluiltok.l
 		else echo "Error: No lexer output file found for wmluiltok"; exit 1; fi; \
 	fi
 	@echo "Adding feature test macros to wmluiltok.c"
-	@sed -i '1i#define _POSIX_C_SOURCE 200809L\n#define _DEFAULT_SOURCE\n#define _GNU_SOURCE' wmluiltok.c
+	@sed -i '1i#define _POSIX_C_SOURCE 200809L\n#define _DEFAULT_SOURCE\n#define _GNU_SOURCE\n#define _BSD_SOURCE\n#include <stdio.h>\n#include <unistd.h>' wmluiltok.c
 
 wmlsynbld.c: wmlparse.h
 

--- a/tools/wml/wmllex.l
+++ b/tools/wml/wmllex.l
@@ -2,6 +2,7 @@
 #define _POSIX_C_SOURCE 200809L
 #define _DEFAULT_SOURCE
 #define _GNU_SOURCE
+#define _BSD_SOURCE
 /*
  * Motif
  *
@@ -32,6 +33,11 @@
 #endif
 #include <stdio.h>
 #include <unistd.h>
+
+/* Explicit declaration for fileno if not available */
+#ifndef fileno
+extern int fileno(FILE *stream);
+#endif
 
 #ifndef XmConst
 #if defined(__STDC__) || !defined( NO_CONST )

--- a/tools/wml/wmluiltok.l
+++ b/tools/wml/wmluiltok.l
@@ -59,9 +59,15 @@
 #define _POSIX_C_SOURCE 200809L
 #define _DEFAULT_SOURCE
 #define _GNU_SOURCE
+#define _BSD_SOURCE
 
 #include <stdio.h>
 #include <unistd.h>
+
+/* Explicit declaration for fileno if not available */
+#ifndef fileno
+extern int fileno(FILE *stream);
+#endif
 
 #define TRUE  1
 #define FALSE 0


### PR DESCRIPTION
Fix `fileno` undeclared identifier error in WML lexer files to enable successful compilation with clang.

The generated `wmllex.c` and `wmluiltok.c` files, produced by flex, use `fileno()` but did not consistently include the necessary headers (`<stdio.h>`, `<unistd.h>`) or feature test macros (`_BSD_SOURCE`) required for its declaration on all systems, especially with stricter compilers like clang. This PR adds explicit declarations and ensures the build system injects the required includes and macros.

---
<a href="https://cursor.com/background-agent?bcId=bc-9ab0f48d-753e-4c7d-8fbb-66a320e9fa06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9ab0f48d-753e-4c7d-8fbb-66a320e9fa06">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

