### PR TITLE
Generate release notes for 2.4.1

### DIFF
--- a/RELEASE_NOTES_2.4.1.md
+++ b/RELEASE_NOTES_2.4.1.md
@@ -1,0 +1,90 @@
+# Motif 2.4.1 Release Notes
+
+## Overview
+
+**Motif 2.4.1** is a significant maintenance release focused on modernization, build system improvements, and enhanced compatibility. This release includes **95 commits** with comprehensive improvements across the entire codebase.
+
+## Key Changes Since 2.4.0
+
+### 🔧 **Build System & Compatibility Enhancements**
+- **C23 Standard Support**: Full compatibility with the latest C23 standard and GCC 15
+- **Alpine Linux Support**: Added comprehensive Alpine Linux build support and container infrastructure
+- **Enhanced Build Configuration**: Improved autotools configuration with logging support and modern compiler compatibility
+- **POSIX Compliance**: Added proper feature test macros for better POSIX compliance
+- **Container Ready**: Builds work correctly in constrained environments and Docker containers
+
+### 🐛 **Code Modernization & Bug Fixes**
+- **Legacy Code Cleanup**: Massive modernization effort converting K&R C style to ANSI C across the entire codebase
+- **Compiler Warning Fixes**: Resolved hundreds of compiler warnings for both GCC and Clang
+- **Memory Safety**: Fixed buffer overflows, uninitialized variables, and pointer type mismatches
+- **Deprecated Function Removal**: Replaced deprecated functions like `readdir_r` with modern alternatives
+- **SVR4/SYSV Legacy Removal**: Cleaned up outdated platform-specific code and preprocessor directives
+
+### 🏗️ **Core Components Improvements**
+- **Comprehensive Logging System**: Added new logging infrastructure throughout the toolkit
+- **WML Tools Enhancement**: Significantly improved Widget Meta Language (WML) tools and lexer files
+- **UIL Compiler Updates**: Modernized UIL compiler with better error handling and warning suppression
+- **MRM Module Fixes**: Fixed Motif Resource Manager compilation issues and function pointer types
+- **Widget Improvements**: Enhanced core Xm library components and widget functionality
+
+### 🧪 **Testing & Development**
+- **Test Framework Updates**: Modernized test infrastructure and renamed test files to consistent naming convention
+- **Code Coverage**: Added gcov code coverage targets for better testing metrics
+- **Development Environment**: Enhanced multi-OS testing with comprehensive CI/CD improvements
+- **Dual Compiler Testing**: Verified compatibility with both GNU and LLVM toolchains
+
+### 📚 **Documentation & Architecture**
+- **Comprehensive Documentation**: Added detailed Motif architecture documentation
+- **Build Documentation**: Enhanced build system documentation and dependency checking
+- **Legacy Cleanup**: Moved outdated configuration files to attic directory
+- **Development Tools**: Updated development environment with modern tooling
+
+### 🔍 **Platform Support**
+- **Alpine Linux**: Full support with musl libc and strict compiler settings
+- **Ubuntu Linux**: Mainstream glibc testing with comprehensive development libraries
+- **Multi-Distribution Testing**: Continuous integration across multiple Linux distributions
+- **Modern Compiler Support**: Full compatibility with GCC 15 and latest Clang versions
+
+## Technical Improvements
+
+### Compiler Compatibility
+- Fixed function pointer type mismatches
+- Resolved signal handler type issues
+- Eliminated void-pointer-to-enum-cast warnings
+- Fixed parentheses-equality warnings
+- Addressed pointer-to-int cast issues
+
+### Build System
+- Integrated preprocessor definitions into build system
+- Enhanced autotools configuration
+- Improved dependency management
+- Added comprehensive feature detection
+
+### Code Quality
+- Removed all `#ifndef NeedFunctionPrototypes` conditional blocks
+- Modernized function declarations across demos and libraries
+- Fixed memory leaks and uninitialized variables
+- Enhanced error handling throughout the codebase
+
+## Backward Compatibility
+
+This release maintains full backward compatibility with existing Motif applications while providing significant improvements in build reliability and modern compiler support.
+
+## Installation
+
+Standard installation process remains unchanged:
+```bash
+./configure
+make
+make install
+```
+
+For Alpine Linux and container environments, additional dependency packages may be required. See the updated build documentation for platform-specific instructions.
+
+---
+
+**Release Date**: [To be filled]  
+**Git Commits**: 95 commits since 2.4.0  
+**Contributors**: [To be filled]  
+
+For detailed technical changes, see the git commit history: `git log 2.4.0..2.4.1`


### PR DESCRIPTION
Add `RELEASE_NOTES_2.4.1.md` to document changes for the upcoming 2.4.1 release.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8e6cbd1-7b9b-4db5-b69f-d26e17f71050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8e6cbd1-7b9b-4db5-b69f-d26e17f71050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

